### PR TITLE
Implement basic skeleton of render system.

### DIFF
--- a/CMake/CompileOptions.cmake
+++ b/CMake/CompileOptions.cmake
@@ -51,6 +51,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         /W4
         ${WARN_AS_ERROR_FLAGS}
 
+        /wd4251
+
         $<$<CONFIG:Release>:
         /Gw
         /Gs-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ add_subdirectory(Sources/Cowdia)
 add_subdirectory(Tests/UnitTests)
 
 # Plugins
+if(WIN32)
 add_subdirectory(Extensions/D3D12Renderer)
+endif()
 
 # Applications
 add_subdirectory(Extensions/TestApp)

--- a/Extensions/D3D12Renderer/D3D12Common.hpp
+++ b/Extensions/D3D12Renderer/D3D12Common.hpp
@@ -1,0 +1,10 @@
+#ifndef D3D12RS_COMMON_HPP
+#define D3D12RS_COMMON_HPP
+
+#ifdef COWDIA_PLATFORM_WIN32
+#define COWDIA_D3D12_API __declspec(dllexport)
+#else
+#define COWDIA_D3D12_API
+#endif
+
+#endif  // D3D12RS_COMMON_HPP

--- a/Extensions/D3D12Renderer/D3D12Plugin.cc
+++ b/Extensions/D3D12Renderer/D3D12Plugin.cc
@@ -1,0 +1,20 @@
+#include "D3D12Plugin.hpp"
+
+#include <Cowdia/Core/Engine.hpp>
+
+namespace Cowdia::Core
+{
+void D3D12Plugin::OnInstalled()
+{
+    renderSystem_ = new Rendering::D3D12RenderSystem;
+
+    Engine::Get().RegisterRenderSystem(renderSystem_);
+}
+
+void D3D12Plugin::OnUninstalled()
+{
+    Engine::Get().UnregisterRenderSystem(renderSystem_);
+
+    SAFE_DELETE(renderSystem_);
+}
+}  // namespace Cowdia::Core

--- a/Extensions/D3D12Renderer/D3D12Plugin.hpp
+++ b/Extensions/D3D12Renderer/D3D12Plugin.hpp
@@ -1,0 +1,23 @@
+#ifndef D3D12RS_PLUGIN_HPP
+#define D3D12RS_PLUGIN_HPP
+
+#include "D3D12Common.hpp"
+#include "D3D12RenderSystem.hpp"
+
+#include <Cowdia/Core/Plugin.hpp>
+#include <Cowdia/Core/PluginManager.hpp>
+
+namespace Cowdia::Core
+{
+class COWDIA_D3D12_API D3D12Plugin final : public Plugin
+{
+ public:
+    void OnInstalled() override;
+    void OnUninstalled() override;
+
+ private:
+    Rendering::D3D12RenderSystem* renderSystem_{ nullptr };
+};
+}  // namespace Cowdia::Core
+
+#endif  // D3D12RS_PLUGIN_HPP

--- a/Extensions/D3D12Renderer/D3D12RenderSystem.cc
+++ b/Extensions/D3D12Renderer/D3D12RenderSystem.cc
@@ -1,0 +1,47 @@
+#include "D3D12RenderSystem.hpp"
+
+#include "D3D12RenderWindow.hpp"
+
+namespace Cowdia::Rendering
+{
+void D3D12RenderSystem::Initialize()
+{
+    hInstance_ = GetModuleHandle(NULL);
+}
+
+void D3D12RenderSystem::Shutdown()
+{
+    SAFE_DELETE(renderWindow_);
+}
+
+std::string D3D12RenderSystem::GetName() const
+{
+    using namespace std::string_literals;
+
+    return "D3D12RenderSystem"s;
+}
+
+RenderWindow* D3D12RenderSystem::GetRenderWindow()
+{
+    if (renderWindow_ == nullptr)
+    {
+        renderWindow_ = new D3D12RenderWindow(hInstance_);
+    }
+
+    return renderWindow_;
+}
+
+bool D3D12RenderSystem::PollEvents()
+{
+    MSG msg;
+    if (PeekMessage(&msg, 0, 0, 0, PM_REMOVE))
+    {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+
+        return true;
+    }
+
+    return false;
+}
+}  // namespace Cowdia::Rendering

--- a/Extensions/D3D12Renderer/D3D12RenderSystem.hpp
+++ b/Extensions/D3D12Renderer/D3D12RenderSystem.hpp
@@ -1,0 +1,31 @@
+#ifndef D3D12RS_RENDER_SYSTEM_HPP
+#define D3D12RS_RENDER_SYSTEM_HPP
+
+#include "D3D12Common.hpp"
+
+#include <Cowdia/Rendering/RenderSystem.hpp>
+#include <Cowdia/Rendering/RenderWindow.hpp>
+
+#include <Windows.h>
+
+namespace Cowdia::Rendering
+{
+class COWDIA_D3D12_API D3D12RenderSystem final : public RenderSystem
+{
+ public:
+    void Initialize() override;
+    void Shutdown() override;
+
+    [[nodiscard]] std::string GetName() const override;
+
+    [[nodiscard]] RenderWindow* GetRenderWindow() override;
+
+    [[nodiscard]] bool PollEvents() override;
+
+ private:
+    HINSTANCE hInstance_{ nullptr };
+    RenderWindow* renderWindow_{ nullptr };
+};
+}
+
+#endif  // D3D12RS_RENDER_SYSTEM_HPP

--- a/Extensions/D3D12Renderer/D3D12RenderWindow.cc
+++ b/Extensions/D3D12Renderer/D3D12RenderWindow.cc
@@ -1,0 +1,114 @@
+#include "D3D12RenderWindow.hpp"
+
+#include <cassert>
+#include <cstring>
+#include <stdexcept>
+
+namespace Cowdia::Rendering
+{
+D3D12RenderWindow::D3D12RenderWindow(HINSTANCE hInstance)
+    : hInstance_(hInstance)
+{
+    // Do nothing.
+}
+
+bool D3D12RenderWindow::Create(int width, int height, bool fullscreen)
+{
+    assert(hwnd_ == nullptr);
+
+    WNDCLASS wc;
+    memset(&wc, 0, sizeof(wc));
+    wc.style = CS_HREDRAW | CS_VREDRAW;
+    wc.lpfnWndProc = &D3D12RenderWindow::MsgProc;
+    wc.hInstance = hInstance_;
+    wc.hIcon = LoadIcon(0, IDI_APPLICATION);
+    wc.hCursor = LoadCursor(0, IDC_ARROW);
+    wc.hbrBackground = (HBRUSH)GetStockObject(NULL_BRUSH);
+    wc.lpszMenuName = 0;
+    wc.lpszClassName = "D3D12RenderWindow";
+
+    if (!RegisterClass(&wc))
+    {
+        return false;
+    }
+
+    DWORD dwStyle = 0;
+
+    if (fullscreen)
+    {
+        dwStyle = WS_EX_TOPMOST | WS_POPUP;
+    }
+    else
+    {
+        dwStyle = WS_OVERLAPPEDWINDOW;
+    }
+
+    RECT rc{ 0, 0, width, height };
+    AdjustWindowRect(&rc, dwStyle, false);
+    const int adjWidth = rc.right - rc.left;
+    const int adjHeight = rc.bottom - rc.top;
+
+    hwnd_ = CreateWindow("D3D12RenderWindow", "D3D12RenderWindow",
+                         dwStyle, CW_USEDEFAULT, CW_USEDEFAULT,
+                         adjWidth, adjHeight, 0, 0, hInstance_, this);
+    if (!hwnd_)
+    {
+        return false;
+    }
+
+    ShowWindow(hwnd_, SW_SHOW);
+    UpdateWindow(hwnd_);
+
+    return true;
+}
+
+void D3D12RenderWindow::Destroy()
+{
+    DestroyWindow(hwnd_);
+    hwnd_ = nullptr;
+}
+
+void D3D12RenderWindow::SetTitle(const std::string& title)
+{
+    SetWindowText(hwnd_, title.c_str());
+}
+
+void D3D12RenderWindow::Resize(int width, int height)
+{
+    RenderWindow::Resize(width, height);
+}
+
+void D3D12RenderWindow::Fullscreen(bool fullscreen)
+{
+    RenderWindow::Fullscreen(fullscreen);
+}
+
+LRESULT D3D12RenderWindow::MsgProc(HWND hwnd, UINT msg, WPARAM wParam,
+                                   LPARAM lParam)
+{
+    if (msg == WM_CREATE)
+    {
+        SetWindowLongPtr(
+            hwnd, GWLP_USERDATA,
+            reinterpret_cast<LONG_PTR>(
+                reinterpret_cast<LPCREATESTRUCT>(lParam)->lpCreateParams));
+        return 0;
+    }
+
+    RenderWindow* window =
+        reinterpret_cast<RenderWindow*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
+
+    if (window != nullptr)
+    {
+        switch (msg)
+        {
+            case WM_DESTROY:
+                window->Destroy();
+                PostQuitMessage(0);
+                return 0;
+        }
+    }
+
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+}  // namespace Cowdia::Rendering

--- a/Extensions/D3D12Renderer/D3D12RenderWindow.hpp
+++ b/Extensions/D3D12Renderer/D3D12RenderWindow.hpp
@@ -1,0 +1,35 @@
+#ifndef D3D12RS_RENDER_WINDOW_HPP
+#define D3D12RS_RENDER_WINDOW_HPP
+
+#include "D3D12Common.hpp"
+
+#include <Cowdia/Rendering/RenderWindow.hpp>
+
+#include <Windows.h>
+
+namespace Cowdia::Rendering
+{
+class COWDIA_D3D12_API D3D12RenderWindow final : public RenderWindow
+{
+ public:
+    D3D12RenderWindow(HINSTANCE hInstance);
+
+    bool Create(int width, int height, bool fullcscreen) override;
+    void Destroy() override;
+
+    void SetTitle(const std::string& title) override;
+
+    void Resize(int width, int height) override;
+
+    void Fullscreen(bool fullscreen) override;
+
+ private:
+    static LRESULT MsgProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+ private:
+    HINSTANCE hInstance_;
+    HWND hwnd_{ nullptr };
+};
+}  // namespace Cowdia::Rendering
+
+#endif  // D3D12RS_RENDER_WINDOW_HPP

--- a/Extensions/D3D12Renderer/D3D12RenderWindow.hpp
+++ b/Extensions/D3D12Renderer/D3D12RenderWindow.hpp
@@ -12,7 +12,7 @@ namespace Cowdia::Rendering
 class COWDIA_D3D12_API D3D12RenderWindow final : public RenderWindow
 {
  public:
-    D3D12RenderWindow(HINSTANCE hInstance);
+    explicit D3D12RenderWindow(HINSTANCE hInstance);
 
     bool Create(int width, int height, bool fullcscreen) override;
     void Destroy() override;

--- a/Extensions/D3D12Renderer/PluginMain.cc
+++ b/Extensions/D3D12Renderer/PluginMain.cc
@@ -1,8 +1,19 @@
-#include <iostream>
+#include "D3D12Plugin.hpp"
 
-int PluginMain()
+#include "D3D12Common.hpp"
+
+using namespace Cowdia::Core;
+
+static D3D12Plugin* pluginInstance;
+
+extern "C" void COWDIA_D3D12_API OnPluginLoad()
 {
-    std::cout << "D3D12Renderer Entry" << std::endl;
+    pluginInstance = new D3D12Plugin;
+    PluginManager::Get().Install(pluginInstance);
+}
 
-    return 0;
+extern "C" void COWDIA_D3D12_API OnPluginUnload()
+{
+    PluginManager::Get().Uninstall(pluginInstance);
+    delete pluginInstance;
 }

--- a/Extensions/TestApp/main.cc
+++ b/Extensions/TestApp/main.cc
@@ -1,3 +1,4 @@
+#include <Cowdia/Core/Engine.hpp>
 #include <Cowdia/Core/PluginManager.hpp>
 
 #include <iostream>
@@ -5,14 +6,44 @@
 using namespace Cowdia;
 using namespace Cowdia::Core;
 
+void Setup();
+void Shutdown();
+
 int main()
 {
-    PluginManager pluginMgr;
+    Engine engine;
 
-    auto plugin = PluginManager::Get().Load("D3D12Renderer");
+    Setup();
 
-    std::cout << "Plugin name: " << plugin->GetName() << std::endl;
-    std::cout << "Plugin main return: " << plugin->GetPluginMain() << std::endl;
+    engine.Run();
+
+    Shutdown();
+}
+
+void Setup()
+{
+    PluginManager::Get().Load("D3D12Renderer");
+    
+    const auto renderSystem =
+        Engine::Get().GetRenderSystemByName("D3D12RenderSystem");
+    Engine::Get().SetRenderSystem(renderSystem);
+
+    renderSystem->Initialize();
+
+    const auto window = renderSystem->GetRenderWindow();
+    if (!window->Create(680, 480, false))
+    {
+        std::cerr << "Cannot create render window." << std::endl;
+        std::exit(1);
+    }
+
+    window->SetTitle("TestApplication");
+}
+
+void Shutdown()
+{
+    const auto renderSystem = Engine::Get().GetRenderSystem();
+    renderSystem->Shutdown();
 
     PluginManager::Get().Unload("D3D12Renderer");
 }

--- a/Includes/Cowdia/Core/Common.hpp
+++ b/Includes/Cowdia/Core/Common.hpp
@@ -1,0 +1,26 @@
+#ifndef COWDIA_COMMON_HPP
+#define COWDIA_COMMON_HPP
+
+#ifndef COWDIA_API
+#ifdef COWDIA_PLATFORM_WIN32
+#ifdef COWDIA_API_EXPORT
+#define COWDIA_API __declspec(dllexport)
+#else
+#define COWDIA_API __declspec(dllimport)
+#endif
+#else
+#define COWDIA_API
+#endif
+#endif
+
+#define SAFE_DELETE(ptr)   \
+    do                     \
+    {                      \
+        if (ptr)           \
+        {                  \
+            delete ptr;    \
+            ptr = nullptr; \
+        }                  \
+    } while (false)
+
+#endif  // COWDIA_COMMON_HPP

--- a/Includes/Cowdia/Core/Engine.hpp
+++ b/Includes/Cowdia/Core/Engine.hpp
@@ -1,0 +1,57 @@
+#ifndef COWDIA_ENGINE_HPP
+#define COWDIA_ENGINE_HPP
+
+#include <Cowdia/Core/Common.hpp>
+#include <Cowdia/Core/PluginManager.hpp>
+#include <Cowdia/Rendering/RenderSystem.hpp>
+#include <Cowdia/Utils/Singleton.hpp>
+
+#include <string>
+#include <unordered_map>
+
+namespace Cowdia::Core
+{
+class COWDIA_API Engine final : public Utils::Singleton<Engine>
+{
+ public:
+    //! Register render system to engine.
+    //! \param renderSystem render system to register.
+    void RegisterRenderSystem(Rendering::RenderSystem* renderSystem);
+
+    //! Unregister render system from engine.
+    //! \param renderSystem render system to unregister.
+    void UnregisterRenderSystem(Rendering::RenderSystem* renderSystem);
+
+    //! Returns render system whose name is \p name.
+    //! \param name name of the render system.
+    Rendering::RenderSystem* GetRenderSystemByName(
+        const std::string& name) const;
+
+    //! Set render system.
+    //! \param renderSystem new render system.
+    void SetRenderSystem(Rendering::RenderSystem* renderSystem);
+
+    //! Returns current render system.
+    Rendering::RenderSystem* GetRenderSystem() const;
+
+    //! Run the engine.
+    void Run();
+
+    //! Stop the engine.
+    void Stop();
+
+    //! Returns engine runnign status.
+    bool IsRunning() const;
+
+ private:
+    bool isRunning_{ false };
+
+    // Managers
+    PluginManager pluginMgr_;
+
+    Rendering::RenderSystem* curRenderSystem_{ nullptr };
+    std::unordered_map<std::string, Rendering::RenderSystem*> renderSystem_;
+};
+}  // namespace Cowdia::Core
+
+#endif  // COWDIA_ENGINE_HPP

--- a/Includes/Cowdia/Core/Plugin.hpp
+++ b/Includes/Cowdia/Core/Plugin.hpp
@@ -1,34 +1,21 @@
 #ifndef COWDIA_PLUGIN_HPP
 #define COWDIA_PLUGIN_HPP
 
-#include <string>
+#include <Cowdia/Core/Common.hpp>
 
 namespace Cowdia::Core
 {
-using PluginHandle = void*;
-using PluginMain = int (*)(void);
-
-class Plugin final
+class COWDIA_API Plugin
 {
  public:
-    //! Constructor with plugin name.
-    explicit Plugin(const std::string& name);
+    //! Default destructor.
+    virtual ~Plugin() = default;
 
-    //! Load plugin.
-    void Load();
+    //! Triggered when this plugin is installed.
+    virtual void OnInstalled() = 0;
 
-    //! Unload plugin.
-    void Unload();
-
-    //! Returns plugin name.
-    [[nodiscard]] const std::string& GetName() const noexcept;
-
-    //! Load plugin main entry.
-    [[nodiscard]] PluginMain GetPluginMain() const;
-
- private:
-    std::string name_;
-    PluginHandle handle_{ nullptr };
+    //! Triggered when this plugin is uninstalled.
+    virtual void OnUninstalled() = 0;
 };
 }  // namespace Cowdia::Core
 

--- a/Includes/Cowdia/Core/PluginAssembly.hpp
+++ b/Includes/Cowdia/Core/PluginAssembly.hpp
@@ -1,0 +1,37 @@
+#ifndef COWDIA_PLUGIN_ASSEMBLY_HPP
+#define COWDIA_PLUGIN_ASSEMBLY_HPP
+
+#include <Cowdia/Core/Common.hpp>
+
+#include <string>
+
+namespace Cowdia::Core
+{
+using PluginHandle = void*;
+using PluginProc = void (*)(void);
+
+class COWDIA_API PluginAssembly final
+{
+ public:
+    //! Constructor with plugin name.
+    explicit PluginAssembly(const std::string& name);
+
+    //! Load plugin.
+    void Load();
+
+    //! Unload plugin.
+    void Unload();
+
+    //! Returns plugin name.
+    [[nodiscard]] const std::string& GetName() const noexcept;
+
+    //! Load plugin procedure.
+    [[nodiscard]] PluginProc GetProc(const std::string& procName) const;
+
+ private:
+    std::string name_;
+    PluginHandle handle_{ nullptr };
+};
+}  // namespace Cowdia::Core
+
+#endif  // COWDIA_PLUGIN_ASSEMBLY_HPP

--- a/Includes/Cowdia/Core/PluginManager.hpp
+++ b/Includes/Cowdia/Core/PluginManager.hpp
@@ -1,15 +1,17 @@
 #ifndef COWDIA_PLUGIN_MANAGER_HPP
 #define COWDIA_PLUGIN_MANAGER_HPP
 
-#include <Cowdia/Utils/Singleton.hpp>
+#include <Cowdia/Core/Common.hpp>
 #include <Cowdia/Core/Plugin.hpp>
+#include <Cowdia/Core/PluginAssembly.hpp>
+#include <Cowdia/Utils/Singleton.hpp>
 
 #include <unordered_map>
-#include <memory>
+#include <set>
 
 namespace Cowdia::Core
 {
-class PluginManager final : public Utils::Singleton<PluginManager>
+class COWDIA_API PluginManager final : public Utils::Singleton<PluginManager>
 {
  public:
     //! Destructor.
@@ -17,14 +19,23 @@ class PluginManager final : public Utils::Singleton<PluginManager>
 
     //! Load plugin.
     //! \param name the name of plugin.
-    [[nodiscard]] Plugin* Load(const std::string& name);
+    void Load(const std::string& name);
 
     //! Unload plugin.
     //! \param name the name of plugin.
     void Unload(const std::string& name);
 
+    //! Install plugin.
+    //! \param plugin the plugin pointer to install.
+    void Install(Plugin* plugin);
+
+    //! Uninstall plugin.
+    //! \param plugin the plugin pointer to uninstall.
+    void Uninstall(Plugin* plugin);
+
  private:
-    std::unordered_map<std::string, std::unique_ptr<Plugin>> plugins_;
+    std::set<Plugin*> plugins_;
+    std::unordered_map<std::string, PluginAssembly*> assemblies_;
 };
 }  // namespace Cowdia::Core
 

--- a/Includes/Cowdia/Rendering/RenderSystem.hpp
+++ b/Includes/Cowdia/Rendering/RenderSystem.hpp
@@ -1,0 +1,35 @@
+#ifndef COWDIA_RENDER_SYSTEM_HPP
+#define COWDIA_RENDER_SYSTEM_HPP
+
+#include <Cowdia/Core/Common.hpp>
+#include <Cowdia/Rendering/RenderWindow.hpp>
+
+#include <string>
+
+namespace Cowdia::Rendering
+{
+class COWDIA_API RenderSystem
+{
+ public:
+    //! Default destructor
+    virtual ~RenderSystem() = default;
+
+    //! Initialize render system.
+    virtual void Initialize() = 0;
+
+    //! Shutdown render system.
+    virtual void Shutdown() = 0;
+
+    //! Returns the name of render system.
+    [[nodiscard]] virtual std::string GetName() const = 0;
+
+    //! Returns render window instance.
+    [[nodiscard]] virtual RenderWindow* GetRenderWindow() = 0;
+
+    //! Poll events.
+    //! \return true if there is events to process else false.
+    [[nodiscard]] virtual bool PollEvents() = 0;
+};
+}  // namespace Cowdia::Rendering
+
+#endif  // COWDIA_RENDER_SYSTEM_HPP

--- a/Includes/Cowdia/Rendering/RenderWindow.hpp
+++ b/Includes/Cowdia/Rendering/RenderWindow.hpp
@@ -1,0 +1,52 @@
+#ifndef COWDIA_RENDER_WINDOW_HPP
+#define COWDIA_RENDER_WINDOW_HPP
+
+#include <Cowdia/Types/Rect.hpp>
+
+#include <string>
+
+namespace Cowdia::Rendering
+{
+class RenderWindow
+{
+ public:
+    //! Default destructor.
+    virtual ~RenderWindow() = default;
+
+    //! Create window.
+    //! \param width window width.
+    //! \param height window height.
+    //! \param fullscreen whether make window fullscreen or not.
+    //! \return true if success to create.
+    virtual bool Create(int width, int height, bool fullscreen) = 0;
+
+    //! Destroy window.
+    virtual void Destroy() = 0;
+
+    //! Set window title.
+    //! \param title new window title.
+    virtual void SetTitle(const std::string& title) = 0;
+
+    //! Resize window.
+    //! \param width new window width.
+    //! \param height new window height.
+    virtual void Resize(int width, int height) = 0;
+
+    //! Set fullscreen mode.
+    //! \param fullscreen whether make window fullscreen or not.
+    virtual void Fullscreen(bool fullscreen) = 0;
+
+    //! Returns window size.
+    Types::Recti GetSize() const;
+
+    //! Returns whether window is full or not.
+    bool IsFullscreen() const;
+
+ protected:
+    int width_{ 0 };
+    int height_{ 0 };
+    bool fullScreen_{ false };
+};
+}
+
+#endif  // COWDIA_RENDER_WINDOW_HPP

--- a/Includes/Cowdia/Rendering/RenderWindow.hpp
+++ b/Includes/Cowdia/Rendering/RenderWindow.hpp
@@ -1,13 +1,14 @@
 #ifndef COWDIA_RENDER_WINDOW_HPP
 #define COWDIA_RENDER_WINDOW_HPP
 
+#include <Cowdia/Core/Common.hpp>
 #include <Cowdia/Types/Rect.hpp>
 
 #include <string>
 
 namespace Cowdia::Rendering
 {
-class RenderWindow
+class COWDIA_API RenderWindow
 {
  public:
     //! Default destructor.
@@ -18,7 +19,7 @@ class RenderWindow
     //! \param height window height.
     //! \param fullscreen whether make window fullscreen or not.
     //! \return true if success to create.
-    virtual bool Create(int width, int height, bool fullscreen) = 0;
+    [[nodiscard]] virtual bool Create(int width, int height, bool fullscreen) = 0;
 
     //! Destroy window.
     virtual void Destroy() = 0;
@@ -30,22 +31,22 @@ class RenderWindow
     //! Resize window.
     //! \param width new window width.
     //! \param height new window height.
-    virtual void Resize(int width, int height) = 0;
+    virtual void Resize(int width, int height);
 
     //! Set fullscreen mode.
     //! \param fullscreen whether make window fullscreen or not.
-    virtual void Fullscreen(bool fullscreen) = 0;
+    virtual void Fullscreen(bool fullscreen);
 
     //! Returns window size.
-    Types::Recti GetSize() const;
+    [[nodiscard]] Types::Recti GetSize() const;
 
     //! Returns whether window is full or not.
-    bool IsFullscreen() const;
+    [[nodiscard]] bool IsFullscreen() const;
 
- protected:
+ private:
     int width_{ 0 };
     int height_{ 0 };
-    bool fullScreen_{ false };
+    bool fullscreen_{ false };
 };
 }
 

--- a/Sources/Cowdia/CMakeLists.txt
+++ b/Sources/Cowdia/CMakeLists.txt
@@ -4,11 +4,12 @@ set(target Cowdia)
 # Sources
 file(GLOB_RECURSE sources ${CMAKE_CURRENT_SOURCE_DIR}/*.cc)
 
-add_library(${target} STATIC ${sources})
+add_library(${target} SHARED ${sources})
 
 target_compile_definitions(${target}
     PRIVATE
     ${DEFAULT_COMPILE_DEFINITIONS}
+    COWDIA_API_EXPORT
 )
 
 target_compile_options(${target}

--- a/Sources/Cowdia/Core/Engine.cc
+++ b/Sources/Cowdia/Core/Engine.cc
@@ -1,0 +1,63 @@
+#include <Cowdia/Core/Engine.hpp>
+
+#include <cassert>
+
+namespace Cowdia::Core
+{
+void Engine::RegisterRenderSystem(Rendering::RenderSystem* renderSystem)
+{
+    assert(renderSystem_.find(renderSystem->GetName()) == end(renderSystem_));
+
+    renderSystem_.emplace(renderSystem->GetName(), renderSystem);
+}
+
+void Engine::UnregisterRenderSystem(Rendering::RenderSystem* renderSystem)
+{
+    renderSystem_.erase(renderSystem->GetName());
+}
+
+Rendering::RenderSystem* Engine::GetRenderSystemByName(
+    const std::string& name) const
+{
+    const auto it = renderSystem_.find(name);
+    if (it == end(renderSystem_))
+        return nullptr;
+
+    return it->second;
+}
+
+void Engine::SetRenderSystem(Rendering::RenderSystem* renderSystem)
+{
+    curRenderSystem_ = renderSystem;
+}
+
+Rendering::RenderSystem* Engine::GetRenderSystem() const
+{
+    return curRenderSystem_;
+}
+
+void Engine::Run()
+{
+    assert(curRenderSystem_ != nullptr);
+
+    isRunning_ = true;
+
+    while (isRunning_)
+    {
+        if (!curRenderSystem_->PollEvents())
+        {
+            // Rendering.
+        }
+    }
+}
+
+void Engine::Stop()
+{
+    isRunning_ = false;
+}
+
+bool Engine::IsRunning() const
+{
+    return isRunning_;
+}
+}  // namespace Cowdia::Core

--- a/Sources/Cowdia/Core/PluginAssembly.cc
+++ b/Sources/Cowdia/Core/PluginAssembly.cc
@@ -37,7 +37,7 @@ int UnloadDynamicLibrary([[maybe_unused]] Cowdia::Core::PluginHandle handle)
     return -1;
 }
 
-Cowdia::Core::PluginMain LoadPluginMain([[maybe_unused]] Cowdia::Core::PluginHandle handle)
+Cowdia::Core::PluginMain LoadPluginProc([[maybe_unused]] Cowdia::Core::PluginHandle handle, [[maybe_unused]] const std::string& procName)
 {
     return nullptr;
 }

--- a/Sources/Cowdia/Core/PluginAssembly.cc
+++ b/Sources/Cowdia/Core/PluginAssembly.cc
@@ -37,7 +37,7 @@ int UnloadDynamicLibrary([[maybe_unused]] Cowdia::Core::PluginHandle handle)
     return -1;
 }
 
-Cowdia::Core::PluginMain LoadPluginProc([[maybe_unused]] Cowdia::Core::PluginHandle handle, [[maybe_unused]] const std::string& procName)
+Cowdia::Core::PluginProc LoadPluginProc([[maybe_unused]] Cowdia::Core::PluginHandle handle, [[maybe_unused]] const std::string& procName)
 {
     return nullptr;
 }

--- a/Sources/Cowdia/Core/PluginAssembly.cc
+++ b/Sources/Cowdia/Core/PluginAssembly.cc
@@ -1,4 +1,4 @@
-#include <Cowdia/Core/Plugin.hpp>
+#include <Cowdia/Core/PluginAssembly.hpp>
 
 #include <cassert>
 #include <stdexcept>
@@ -21,10 +21,10 @@ int UnloadDynamicLibrary(Cowdia::Core::PluginHandle handle)
     return FreeLibrary(reinterpret_cast<HINSTANCE>(handle));
 }
 
-Cowdia::Core::PluginMain LoadPluginMain(Cowdia::Core::PluginHandle handle)
+Cowdia::Core::PluginProc LoadPluginProc(Cowdia::Core::PluginHandle handle, const std::string& procName)
 {
-    return reinterpret_cast<Cowdia::Core::PluginMain>(
-        GetProcAddress(reinterpret_cast<HINSTANCE>(handle), "PluginMain"));
+    return reinterpret_cast<Cowdia::Core::PluginProc>(
+        GetProcAddress(reinterpret_cast<HINSTANCE>(handle), procName.c_str()));
 }
 #else
 Cowdia::Core::PluginHandle LoadDynamicLibrary([[maybe_unused]] const std::string& name)
@@ -46,12 +46,12 @@ Cowdia::Core::PluginMain LoadPluginMain([[maybe_unused]] Cowdia::Core::PluginHan
 
 namespace Cowdia::Core
 {
-Plugin::Plugin(const std::string& name) : name_(name)
+PluginAssembly::PluginAssembly(const std::string& name) : name_(name)
 {
     // Do nothing.
 }
 
-void Plugin::Load()
+void PluginAssembly::Load()
 {
     using namespace std::string_literals;
 
@@ -63,7 +63,7 @@ void Plugin::Load()
     }
 }
 
-void Plugin::Unload()
+void PluginAssembly::Unload()
 {
     using namespace std::string_literals;
 
@@ -77,15 +77,15 @@ void Plugin::Unload()
     handle_ = nullptr;
 }
 
-const std::string& Plugin::GetName() const noexcept
+const std::string& PluginAssembly::GetName() const noexcept
 {
     return name_;
 }
 
-PluginMain Plugin::GetPluginMain() const
+PluginProc PluginAssembly::GetProc(const std::string& procName) const
 {
     assert(handle_ != nullptr);
 
-    return LoadPluginMain(handle_);
+    return LoadPluginProc(handle_, procName);
 }
 }  // namespace Cowdia::Core

--- a/Sources/Cowdia/Rendering/RenderWindow.cc
+++ b/Sources/Cowdia/Rendering/RenderWindow.cc
@@ -1,0 +1,14 @@
+#include <Cowdia/Rendering/RenderWindow.hpp>
+
+namespace Cowdia::Rendering
+{
+Types::Recti RenderWindow::GetSize() const
+{
+    return Types::Recti(width_, height_);
+}
+
+bool RenderWindow::IsFullscreen() const
+{
+    return fullScreen_;
+}
+}  // namespace Cowdia::Rendering

--- a/Sources/Cowdia/Rendering/RenderWindow.cc
+++ b/Sources/Cowdia/Rendering/RenderWindow.cc
@@ -2,6 +2,17 @@
 
 namespace Cowdia::Rendering
 {
+void RenderWindow::Resize(int width, int height)
+{
+    width_ = width;
+    height_ = height;
+}
+
+void RenderWindow::Fullscreen(bool fullscreen)
+{
+    fullscreen_ = fullscreen;
+}
+
 Types::Recti RenderWindow::GetSize() const
 {
     return Types::Recti(width_, height_);
@@ -9,6 +20,6 @@ Types::Recti RenderWindow::GetSize() const
 
 bool RenderWindow::IsFullscreen() const
 {
-    return fullScreen_;
+    return fullscreen_;
 }
 }  // namespace Cowdia::Rendering


### PR DESCRIPTION
This revision includes:

- Refactor plugin system.
  - Create `PluginAssembly`, `Plugin` class.
  - Edit `PluginManager` class.
- Add skeleton for render system.
  - Create `RenderSystem` class.
  - Create `RenderWindow` class.
  - Create `Engine` class.
- Add dllimport/dllexport
- Ignore compile warning (4251 in msvc)
- Implement D3D12 render system plugin. [WIP]
  - Create `D3D12Plugin` class.
  - Create `D3D12RenderSystem` class.
  - Create `D3D12RenderWindow` class.